### PR TITLE
Sevre arbitrary files from /app/staticsite

### DIFF
--- a/urbit/app/staticsite.hoon
+++ b/urbit/app/staticsite.hoon
@@ -1,11 +1,4 @@
 /+  *server, default-agent, verb
-/=  index
-  /^  octs
-  /;  as-octs:mimes:html
-  /:  /===/app/staticsite/index
-  /|  /html/
-      /~  ~
-  ==
 ::
 %+  verb  |
 ^-  agent:gall
@@ -28,7 +21,47 @@
   =+  !<([eyre-id=@ta =inbound-request:eyre] vase)
   :_  this
   %+  give-simple-payload:app  eyre-id
-  (html-response:gen index)
+  |^  ::  exclusively handle get requests. try to load the requested file from
+      ::  clay, under /app/staticsite. if the requested file doesn't exist, or
+      ::  it's a different kind of request, respond with 404.
+      ::
+      ?.  ?=(%'GET' method.request.inbound-request)
+        not-found:gen
+      =/  =request-line
+        %-  parse-request-line
+        url.request.inbound-request
+      =/  ext=@ta
+        (fall ext.request-line %html)
+      =/  file=(unit octs)
+        ?.  ?=([%'~staticsite' *] site.request-line)  ~
+        (get-file-at /app/[dap.bowl] t.site.request-line ext)
+      ?~  file  not-found:gen
+      ?+  ext  not-found:gen
+        %html  (html-response:gen u.file)
+        %css   (css-response:gen u.file)
+        %js    (js-response:gen u.file)
+      ==
+  ::
+  ++  get-file-at
+    |=  [base=path file=path ext=@ta]
+    ^-  (unit octs)
+    ::  only support html, css and js files for now.
+    ::  other filetypes might need more work to get as octs.
+    ::
+    ?.  ?=(?(%html %css %js) ext)
+      ~
+    =/  =path
+      :*  (scot %p our.bowl)
+          q.byk.bowl
+          (scot %da now.bowl)
+          (snoc (weld base file) ext)
+      ==
+    ?.  .^(? %cu path)
+      ~
+    %-  some
+    %-  as-octs:mimes:html
+    .^(@ %cx path)
+  --
 ::
 ++  on-watch
   |=  =path


### PR DESCRIPTION
Loads arbitrary (html, css and js) files from the /app/staticsite directory.
If no file extension is provided, tries to load the .html file at that path.

If the file does not exist in clay, or the request is not an appropriate GET
request, responds with a 404.

Maybe you want different behavior here wrt dealing with extension-less paths, like appending `/index/html` instead of just `/html`.

Also I humble propose renaming the app and its paths/bindings to just `static`, but that seems out of scope for this PR.